### PR TITLE
release: v0.14.1 changelog and backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v0.14.1] - 2022-07-13
+
+### Improvements
+
+* (rpc) [\#1169](https://github.com/evmos/ethermint/pull/1169) Remove unnecessary queries from `getBlockNumber` function
+
 ## [v0.14.0] - 2022-04-19
 
 ### API Breaking

--- a/rpc/ethereum/backend/backend.go
+++ b/rpc/ethereum/backend/backend.go
@@ -62,6 +62,7 @@ type Backend interface {
 	BlockByHash(blockHash common.Hash) (*ethtypes.Block, error)
 	CurrentHeader() *ethtypes.Header
 	HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Header, error)
+	GetBlockNumberByHash(blockHash common.Hash) (*big.Int, error)
 	HeaderByHash(blockHash common.Hash) (*ethtypes.Header, error)
 	PendingTransactions() ([]*sdk.Tx, error)
 	GetTransactionCount(address common.Address, blockNum types.BlockNumber) (*hexutil.Uint64, error)
@@ -506,6 +507,18 @@ func (e *EVMBackend) HeaderByNumber(blockNum types.BlockNumber) (*ethtypes.Heade
 
 	ethHeader := types.EthHeaderFromTendermint(resBlock.Block.Header, bloom, baseFee)
 	return ethHeader, nil
+}
+
+// GetBlockNumberByHash returns the block height of given block hash
+func (e *EVMBackend) GetBlockNumberByHash(blockHash common.Hash) (*big.Int, error) {
+	resBlock, err := e.GetTendermintBlockByHash(blockHash)
+	if err != nil {
+		return nil, err
+	}
+	if resBlock == nil {
+		return nil, errors.Errorf("block not found for hash %s", blockHash.Hex())
+	}
+	return big.NewInt(resBlock.Block.Height), nil
 }
 
 // HeaderByHash returns the block header identified by hash.

--- a/rpc/ethereum/namespaces/eth/api.go
+++ b/rpc/ethereum/namespaces/eth/api.go
@@ -1102,11 +1102,11 @@ func (e *PublicAPI) getBlockNumber(blockNrOrHash rpctypes.BlockNumberOrHash) (rp
 	case blockNrOrHash.BlockHash == nil && blockNrOrHash.BlockNumber == nil:
 		return rpctypes.EthEarliestBlockNumber, fmt.Errorf("types BlockHash and BlockNumber cannot be both nil")
 	case blockNrOrHash.BlockHash != nil:
-		blockHeader, err := e.backend.HeaderByHash(*blockNrOrHash.BlockHash)
+		blockNumber, err := e.backend.GetBlockNumberByHash(*blockNrOrHash.BlockHash)
 		if err != nil {
 			return rpctypes.EthEarliestBlockNumber, err
 		}
-		return rpctypes.NewBlockNumber(blockHeader.Number), nil
+		return rpctypes.NewBlockNumber(blockNumber), nil
 	case blockNrOrHash.BlockNumber != nil:
 		return *blockNrOrHash.BlockNumber, nil
 	default:


### PR DESCRIPTION
## Description

This PR backports a patch for the `eth_getBalance` JSON-RPC endpoint in order to query historical archive nodes:

- fix(rpc): optimize `eth_getBalance` endpoint (#1169)

Related issue: https://linear.app/evmos/issue/ENG-577/release-ethermint-and-evmos-patches-for-historical-archive-nodes