### PR TITLE
Websockets ping loop

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,1 +1,1 @@
-image: ghcr.io/notional-labs/ethermint
+image: ghcr.io/notional-labs/cosmos

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,1 @@
+image: ghcr.io/notional-labs/ethermint

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/tendermint/tendermint v0.34.20
 	github.com/tendermint/tm-db v0.6.7
 	github.com/tyler-smith/go-bip39 v1.1.0
+	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9
 	golang.org/x/text v0.3.7
 	google.golang.org/genproto v0.0.0-20220628213854-d9e0b6570c03
 	google.golang.org/grpc v1.48.0
@@ -167,7 +168,6 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
 	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/gorilla/mux"
@@ -31,6 +32,15 @@ import (
 	"github.com/evmos/ethermint/rpc/types"
 	"github.com/evmos/ethermint/server/config"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+const (
+	wsReadBuffer       = 1024
+	wsWriteBuffer      = 1024
+	wsPingInterval     = 60 * time.Second
+	wsPingWriteTimeout = 5 * time.Second
+	wsPongTimeout      = 30 * time.Second
+	wsMessageSizeLimit = 15 * 1024 * 1024
 )
 
 type WebsocketsServer interface {

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -151,6 +151,7 @@ func (s *websocketsServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // pingLoop sends periodic ping frames when the connection is idle.
 // this is the thing that is keeping ethereum websocket connections alive
+// It has been adapted from geth: https://github.com/ethereum/go-ethereum/blob/4c114af5024943a7471aeccdf5e536584c1e21b4/rpc/websocket.go#L290-L314
 func (s *websocketsServer) pingLoop(wsConn *wsConn) {
 	timer := time.NewTimer(wsPingInterval)
 	defer timer.Stop()


### PR DESCRIPTION
## Description

Evmos websockets were dying after about 5 minutes.  Comparing our websocket code to geth's, I found that geth had a pingLoop that kept connections alive, but that their websocket implementation was quite different.  This PR borrows only the PingLoop.



* Still untested, making a build with v7 now
* Adds a pingLoop after readLoop
* Adds .gitpod.yml for dev env ease
* Does not fully implement ethereum's websocketcodec


______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
