### PR TITLE
tests: add gas consumption test

### DIFF
--- a/tests/integration_tests/test_gas.py
+++ b/tests/integration_tests/test_gas.py
@@ -1,0 +1,37 @@
+from .utils import (
+    ADDRS,
+    CONTRACTS,
+    KEYS,
+    deploy_contract,
+    send_transaction,
+    w3_wait_for_new_blocks,
+)
+
+
+def test_equivalent_gas_consumption(geth, ethermint):
+    tx_value = 10
+
+    # send a transaction with geth
+    geth_gas_price = geth.w3.eth.gas_price
+    tx = {"to": ADDRS["community"], "value": tx_value, "gasPrice": geth_gas_price}
+    geth_reciept = send_transaction(geth.w3, tx, KEYS["validator"])
+
+    # send an equivalent transaction with ethermint
+    ethermint_gas_price = ethermint.w3.eth.gas_price
+    tx = {"to": ADDRS["community"], "value": tx_value, "gasPrice": ethermint_gas_price}
+    ethermint_reciept = send_transaction(ethermint.w3, tx, KEYS["validator"])
+
+    # ensure that the gasUsed is equivalent
+    assert geth_reciept.gasUsed == ethermint_reciept.gasUsed
+
+    w3_wait_for_new_blocks(geth.w3, 5)
+    w3_wait_for_new_blocks(ethermint.w3, 5)
+
+    # repeat the above process with contract deployment
+    _, geth_contract_reciept = deploy_contract(
+        geth.w3,
+        CONTRACTS["TestERC20A"])
+    _, ethermint_contract_reciept = deploy_contract(
+        ethermint.w3,
+        CONTRACTS["TestERC20A"])
+    assert geth_contract_reciept.gasUsed == ethermint_contract_reciept.gasUsed


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [ENG-1034](https://linear.app/evmos/issue/ENG-1034/compare-geth-gas-consumption-on-integration-tests) (Linear)

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- after #1460 , gas consumption on Ethermint should be similar to Geth
- added integration test to ensure that gas consumption when sending transactions is equivalent

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
