### PR TITLE
fix(tests): Delete inconsistent test

### DIFF
--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -887,18 +887,6 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			},
 			expPass: false,
 		},
-		// {
-		// 	msg: "trace config - Execution Timeout",
-		// 	malleate: func() {
-		// 		traceConfig = &types.TraceConfig{
-		// 			DisableStack:   true,
-		// 			DisableStorage: true,
-		// 			EnableMemory:   false,
-		// 			Timeout:        "0s",
-		// 		}
-		// 	},
-		// 	expPass: false,
-		// },
 		{
 			msg: "default tracer with contract creation tx as predecessor but 'create' param disabled",
 			malleate: func() {

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -887,18 +887,18 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			},
 			expPass: false,
 		},
-		{
-			msg: "trace config - Execution Timeout",
-			malleate: func() {
-				traceConfig = &types.TraceConfig{
-					DisableStack:   true,
-					DisableStorage: true,
-					EnableMemory:   false,
-					Timeout:        "0s",
-				}
-			},
-			expPass: false,
-		},
+		// {
+		// 	msg: "trace config - Execution Timeout",
+		// 	malleate: func() {
+		// 		traceConfig = &types.TraceConfig{
+		// 			DisableStack:   true,
+		// 			DisableStorage: true,
+		// 			EnableMemory:   false,
+		// 			Timeout:        "0s",
+		// 		}
+		// 	},
+		// 	expPass: false,
+		// },
 		{
 			msg: "default tracer with contract creation tx as predecessor but 'create' param disabled",
 			malleate: func() {
@@ -984,8 +984,8 @@ func (suite *KeeperTestSuite) TestTraceTx() {
 			} else {
 				suite.Require().Error(err)
 			}
-            // Reset for next test case
-            chainID = nil
+			// Reset for next test case
+			chainID = nil
 		})
 	}
 
@@ -1140,9 +1140,9 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 				TraceConfig: traceConfig,
 			}
 
-            if chainID != nil {
-              traceReq.ChainId = chainID.Int64()
-            }
+			if chainID != nil {
+				traceReq.ChainId = chainID.Int64()
+			}
 
 			res, err := suite.queryClient.TraceBlock(sdk.WrapSDKContext(suite.ctx), &traceReq)
 
@@ -1157,8 +1157,8 @@ func (suite *KeeperTestSuite) TestTraceBlock() {
 			} else {
 				suite.Require().Error(err)
 			}
-            // Reset for next case
-            chainID = nil
+			// Reset for next case
+			chainID = nil
 		})
 	}
 
@@ -1175,7 +1175,7 @@ func (suite *KeeperTestSuite) TestNonceInQuery() {
 
 	// do an EthCall/EstimateGas with nonce 0
 	ctorArgs, err := types.ERC20Contract.ABI.Pack("", address, supply)
-    suite.Require().NoError(err)
+	suite.Require().NoError(err)
 
 	data := append(types.ERC20Contract.Bin, ctorArgs...)
 	args, err := json.Marshal(&types.TransactionArgs{


### PR DESCRIPTION
Closes: #XXX

## Description

The timeout traceTx test behaviour is inconsistent. It relies on the timeout thread to be assigned resources before the traceTx is executed.
If we want to keep this test, we need to find a way to make a super expensive tracetx call (but it may still behave the same way)
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
