### PR TITLE
fix(ante): Add unlimited gas handle.

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -22,6 +22,8 @@ func BlockGasLimit(ctx sdk.Context) uint64 {
 	maxGas := cp.Block.MaxGas
 	if maxGas > 0 {
 		return uint64(maxGas)
+	} else if maxGas == -1 {
+		return ^uint64(0)
 	}
 
 	return 0


### PR DESCRIPTION
This is mainly for testing, as in the SDK we use the idiom that -1 means unlimted gas. We can just leave it out if we'd like, but thought i'd suggest.