### PR TITLE
imp (evm): make missing key error message during SendTransaction more verbose

### DIFF
--- a/rpc/backend/sign_tx.go
+++ b/rpc/backend/sign_tx.go
@@ -39,7 +39,7 @@ func (b *Backend) SendTransaction(args evmtypes.TransactionArgs) (common.Hash, e
 	_, err := b.clientCtx.Keyring.KeyByAddress(sdk.AccAddress(args.GetFrom().Bytes()))
 	if err != nil {
 		b.logger.Error("failed to find key in keyring", "address", args.GetFrom(), "error", err.Error())
-		return common.Hash{}, fmt.Errorf("%s; %s", keystore.ErrNoMatch, err.Error())
+		return common.Hash{}, fmt.Errorf("failed to find key in the node's keyring; %s; %s", keystore.ErrNoMatch, err.Error())
 	}
 
 	if args.ChainID != nil && (b.chainID).Cmp((*big.Int)(args.ChainID)) != 0 {


### PR DESCRIPTION
This minor change improves the verbosity of the error, that occurs during a call to the `eth_sendTransaction` endpoint, should the sender address not be found in the used keyring.

Since Go-Ethereum is (at least to my knowledge) not concerned with using different keyring backends etc. as on Cosmos, the raised error is not too verbose. IMO this is a small improvement for developer experience.