### PR TITLE
fix (docs): replace evmos.dev links with docs.evmos.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ For additional instructions, standards and style guides, please refer to the [Co
 
 ## Careers
 
-See our open positions on [Cosmos Jobs](https://jobs.cosmos.network/project/evmos-d0sk1uxuh-remote/), [Notion](https://tharsis.notion.site), or feel free to [reach out](mailto:careers@thars.is) via email.
+See our open positions on [Cosmos Jobs](https://jobs.cosmos.network/project/evmos-d0sk1uxuh-remote/), [Greenhouse](https://boards.eu.greenhouse.io/evmos), or feel free to [reach out](mailto:careers@thars.is) via email.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ethermint is a scalable and interoperable Ethereum library, built on Proof-of-St
 
 ## Installation
 
-For prerequisites and detailed build instructions please read the Evmos [Installation](https://evmos.dev/quickstart/installation.html) instructions. Once the dependencies are installed, run:
+For prerequisites and detailed build instructions please read the Evmos [Installation](https://docs.evmos.org/validators/quickstart/installation.html) instructions. Once the dependencies are installed, run:
 
 ```bash
 make install

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ For additional instructions, standards and style guides, please refer to the [Co
 
 ## Careers
 
-See our open positions on [Cosmos Jobs](https://jobs.cosmos.network/project/evmos-d0sk1uxuh-remote/), [Greenhouse](https://boards.eu.greenhouse.io/evmos), or feel free to [reach out](mailto:careers@thars.is) via email.
+See our open positions on [Greenhouse](https://boards.eu.greenhouse.io/evmos).

--- a/x/evm/spec/02_state.md
+++ b/x/evm/spec/02_state.md
@@ -229,7 +229,7 @@ The `GenesisAccount` type corresponds to an adaptation of the Ethereum `GenesisA
 
 Its main difference is that the one on Ethermint uses a custom `Storage` type that uses a slice instead of maps for the evm `State` (due to non-determinism), and that it doesn't contain the private key field.
 
-It is also important to note that since the `auth` module on the Cosmos SDK manages the account state,  the `Address` field must correspond to an existing `EthAccount` that is stored in the `auth`'s module `Keeper` (i.e `AccountKeeper`). Addresses use the **[EIP55](https://eips.ethereum.org/EIPS/eip-55)** hex **[format](https://evmos.dev/basics/accounts.html#address-formats-for-clients)** on `genesis.json`.
+It is also important to note that since the `auth` module on the Cosmos SDK manages the account state,  the `Address` field must correspond to an existing `EthAccount` that is stored in the `auth`'s module `Keeper` (i.e `AccountKeeper`). Addresses use the **[EIP55](https://eips.ethereum.org/EIPS/eip-55)** hex **[format](https://docs.evmos.org/users/technical_concepts/accounts.html#address-formats-for-clients)** on `genesis.json`.
 
 ```go
 type GenesisAccount struct {

--- a/x/evm/spec/06_hooks.md
+++ b/x/evm/spec/06_hooks.md
@@ -40,7 +40,7 @@ The error returned by the hooks is translated to a VM error `failed to process n
 
 ## Use Case: Call Native ERC20 Module on Evmos
 
-Here is an example taken from the Evmos [erc20 module](https://evmos.dev/modules/erc20/) that shows how the `EVMHooks` supports a contract calling a native module to convert ERC-20 Tokens into Cosmos native Coins. Following the steps from above.
+Here is an example taken from the Evmos [erc20 module](https://docs.evmos.org/modules/erc20/) that shows how the `EVMHooks` supports a contract calling a native module to convert ERC-20 Tokens into Cosmos native Coins. Following the steps from above.
 
 You can define and emit a `Transfer` log signature in the smart contract like this:
 


### PR DESCRIPTION
This PR replaces the remaining links pointing to evmos.dev with up-to-date links to docs.evmos.org