### PR TITLE
chore: run gofumpt for non-generated files & fix tools/tools.go

### DIFF
--- a/rpc/backend/backend_suite_test.go
+++ b/rpc/backend/backend_suite_test.go
@@ -88,7 +88,6 @@ func (suite *BackendTestSuite) SetupTest() {
 	// Add codec
 	encCfg := encoding.MakeConfig(app.ModuleBasics)
 	suite.backend.clientCtx.Codec = encCfg.Codec
-
 }
 
 // buildEthereumTx returns an example legacy Ethereum transaction

--- a/rpc/backend/call_tx_test.go
+++ b/rpc/backend/call_tx_test.go
@@ -489,5 +489,4 @@ func (suite *BackendTestSuite) TestGasPrice() {
 			}
 		})
 	}
-
 }

--- a/rpc/backend/chain_info_test.go
+++ b/rpc/backend/chain_info_test.go
@@ -165,7 +165,6 @@ func (suite *BackendTestSuite) TestChainId() {
 				var header metadata.MD
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterParamsInvalidHeight(queryClient, &header, int64(1))
-
 			},
 			expChainId,
 			true,
@@ -387,7 +386,7 @@ func (suite *BackendTestSuite) TestFeeHistory() {
 		{
 			"fail - Invalid base fee",
 			func(validator sdk.AccAddress) {
-				//baseFee := sdk.NewInt(1)
+				// baseFee := sdk.NewInt(1)
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				suite.backend.cfg.JSONRPC.FeeHistoryCap = 2

--- a/rpc/backend/client_test.go
+++ b/rpc/backend/client_test.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"context"
+	"testing"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
@@ -18,7 +20,6 @@ import (
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
 	tmrpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
-	"testing"
 )
 
 // Client defines a mocked object that implements the Tendermint JSON-RPC Client
@@ -97,6 +98,7 @@ func RegisterBlockMultipleTxs(
 	client.On("Block", rpc.ContextWithHeight(height), mock.AnythingOfType("*int64")).Return(resBlock, nil)
 	return resBlock, nil
 }
+
 func RegisterBlock(
 	client *mocks.Client,
 	height int64,

--- a/rpc/backend/evm_query_client_test.go
+++ b/rpc/backend/evm_query_client_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
@@ -18,8 +21,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"strconv"
-	"testing"
 )
 
 // QueryClient defines a mocked object that implements the ethermint GRPC

--- a/rpc/backend/filters_test.go
+++ b/rpc/backend/filters_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"encoding/json"
+
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/evmos/ethermint/rpc/backend/mocks"
@@ -11,7 +12,6 @@ import (
 )
 
 func (suite *BackendTestSuite) TestGetLogs() {
-
 	_, bz := suite.buildEthereumTx()
 	block := tmtypes.MakeBlock(1, []tmtypes.Tx{bz}, nil, nil)
 	logs := make([]*evmtypes.Log, 0, 1)

--- a/rpc/backend/node_info_test.go
+++ b/rpc/backend/node_info_test.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"fmt"
+	"math/big"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -11,7 +13,6 @@ import (
 	ethermint "github.com/evmos/ethermint/types"
 	"github.com/spf13/viper"
 	tmrpcclient "github.com/tendermint/tendermint/rpc/client"
-	"math/big"
 )
 
 func (suite *BackendTestSuite) TestRPCMinGasPrice() {
@@ -190,7 +191,6 @@ func (suite *BackendTestSuite) TestSyncing() {
 				RegisterStatus(client)
 				status, _ := client.Status(suite.backend.ctx)
 				status.SyncInfo.CatchingUp = true
-
 			},
 			map[string]interface{}{
 				"startingBlock": hexutil.Uint64(0),
@@ -254,7 +254,7 @@ func (suite *BackendTestSuite) TestSetEtherbase() {
 				c := sdk.NewDecCoin("aphoton", sdk.NewIntFromBigInt(big.NewInt(1)))
 				suite.backend.cfg.SetMinGasPrices(sdk.DecCoins{c})
 				delAddr, _ := suite.backend.GetCoinbase()
-				//account, _ := suite.backend.clientCtx.AccountRetriever.GetAccount(suite.backend.clientCtx, delAddr)
+				// account, _ := suite.backend.clientCtx.AccountRetriever.GetAccount(suite.backend.clientCtx, delAddr)
 				delCommonAddr := common.BytesToAddress(delAddr.Bytes())
 				request := &authtypes.QueryAccountRequest{Address: sdk.AccAddress(delCommonAddr.Bytes()).String()}
 				requestMarshal, _ := request.Marshal()

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/crypto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -79,7 +80,7 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 		{
 			"fail - block not found",
 			func() {
-				//var header metadata.MD
+				// var header metadata.MD
 				client := suite.backend.clientCtx.Client.(*mocks.Client)
 				RegisterBlockError(client, 1)
 			},
@@ -180,7 +181,7 @@ func (suite *BackendTestSuite) TestTraceTransaction() {
 			suite.backend.indexer = indexer.NewKVIndexer(db, tmlog.NewNopLogger(), suite.backend.clientCtx)
 
 			err := suite.backend.indexer.IndexBlock(tc.block, tc.responseBlock)
-            suite.Require().NoError(err)
+			suite.Require().NoError(err)
 			txResult, err := suite.backend.TraceTransaction(txHash, nil)
 
 			if tc.expPass {
@@ -223,7 +224,6 @@ func (suite *BackendTestSuite) TestTraceBlock() {
 			func() {
 				queryClient := suite.backend.queryClient.QueryClient.(*mocks.EVMQueryClient)
 				RegisterTraceBlock(queryClient, []*evmtypes.MsgEthereumTx{msgEthTx})
-
 			},
 			[]*evmtypes.TxTraceResult{},
 			&resBlockFilled,

--- a/rpc/backend/tx_info_test.go
+++ b/rpc/backend/tx_info_test.go
@@ -2,6 +2,8 @@ package backend
 
 import (
 	"fmt"
+	"math/big"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -16,7 +18,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 	"google.golang.org/grpc/metadata"
-	"math/big"
 )
 
 func (suite *BackendTestSuite) TestGetTransactionByHash() {
@@ -299,7 +300,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockAndIndex() {
 		1,
 		0,
 		big.NewInt(1),
-        suite.backend.chainID,
+		suite.backend.chainID,
 	)
 	testCases := []struct {
 		name         string
@@ -393,7 +394,7 @@ func (suite *BackendTestSuite) TestGetTransactionByBlockNumberAndIndex() {
 		1,
 		0,
 		big.NewInt(1),
-        suite.backend.chainID,
+		suite.backend.chainID,
 	)
 	testCases := []struct {
 		name         string
@@ -554,7 +555,6 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 				RegisterParamsWithoutHeader(queryClient, 1)
 				RegisterBlock(client, 1, txBz)
 				RegisterBlockResults(client, 1)
-
 			},
 			msgEthereumTx,
 			&types.Block{Header: types.Header{Height: 1}, Data: types.Data{Txs: []types.Tx{txBz}}},
@@ -585,8 +585,8 @@ func (suite *BackendTestSuite) TestGetTransactionReceipt() {
 
 			db := dbm.NewMemDB()
 			suite.backend.indexer = indexer.NewKVIndexer(db, tmlog.NewNopLogger(), suite.backend.clientCtx)
-            err := suite.backend.indexer.IndexBlock(tc.block, tc.blockResult)
-            suite.Require().NoError(err)
+			err := suite.backend.indexer.IndexBlock(tc.block, tc.blockResult)
+			suite.Require().NoError(err)
 
 			txReceipt, err := suite.backend.GetTransactionReceipt(common.HexToHash(tc.tx.Hash))
 			if tc.expPass {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -21,20 +21,5 @@ import (
 	_ "github.com/onsi/ginkgo/v2"
 )
 
-// This file imports // Copyright 2021 Evmos Foundation
-// This file is part of Evmos' Ethermint library.
-//
-// The Ethermint library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The Ethermint library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the Ethermint library. If not, see https://github.com/evmos/ethermint/blob/main/LICENSE
-packages that are used when running go generate, or used
+// This file imports packages that are used when running go generate, or used
 // during the development process but not otherwise depended on by built code.


### PR DESCRIPTION
This PR executes `gofumpt` for all files, that are not automatically generated.

Additionally, it fixes the comment in `tools/tools.go`, [that was broken](https://github.com/evmos/ethermint/pull/1558/files#diff-e653d1150bfff4aea5ecd6936da16287f53de5d6613833c5bf6ccb4964e2bce4) in the automated addition of the license information to all Go files in #1558.